### PR TITLE
Update API base URL

### DIFF
--- a/MMM-VigilanceMeteoFrance.js
+++ b/MMM-VigilanceMeteoFrance.js
@@ -25,7 +25,7 @@ Module.register("MMM-VigilanceMeteoFrance",{
 
 		initialLoadDelay: 0, // 0 seconds delay
 
-		apiBase: "http://www.vigilance.meteofrance.com/",
+		apiBase: "http://vigilance2019.meteofrance.com/",
 		vigiEndpoint: "data/NXFR33_LFPW_.xml",
 		frenchDepartmentsTable: {
 			"01": "Ain",

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The following properties can be configured:
 | `useColorLegend`             | Use the colored icons. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
 | `initialLoadDelay`           | The initial delay before loading. If you have multiple modules that use the same API key, you might want to delay one of the requests. (Milliseconds) <br><br> **Possible values:** `1000` - `5000` <br> **Default value:**  `0`
 | `retryDelay`                 | The delay before retrying after a request failure. (Milliseconds) <br><br> **Possible values:** `1000` - `60000` <br> **Default value:**  `2500`
-| `apiBase`                    | The Météo France API base URL. <br><br> **Default value:**  `'http://www.vigilance.weatherfrance.com/'`
+| `apiBase`                    | The Météo France API base URL. <br><br> **Default value:**  `'http://vigilance2019.weatherfrance.com/'`
 | `vigiEndpoint`               | The Vigilance API endPoint. <br><br> **Default value:**  `'data/NXFR33_LFPW_.xml'`
 | `frenchDepartmentsTable`     | The conversion table to convert the department number to department name. 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "MMM-VigilanceMeteoFrance",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Module for a Magic Mirror device display the current level of vigilance of weather phenomena in metropolitan france.",
   "main": "MMM-VigilanceMeteoFrance.js",
   "author": "Grena",


### PR DESCRIPTION
Taking into account the change in the Météo France API base URL following the last update of the service (June 2020).